### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "node-red-node-email": "0.1.*",
     "node-red-node-rbe": "0.1.*",
     "node-red-node-twitter": "0.1.*",
-    "node-uuid": "1.4.7",
     "nopt": "3.0.6",
     "oauth2orize": "1.2.2",
     "on-headers": "1.0.1",
@@ -83,6 +82,7 @@
     "sentiment": "1.0.6",
     "uglify-js": "2.6.2",
     "url": "0.11.0",
+    "uuid": "^3.0.0",
     "when": "3.7.7",
     "ws": "0.8.1",
     "xml2js": "0.4.16"

--- a/xively/habanero/auth.js
+++ b/xively/habanero/auth.js
@@ -1,6 +1,6 @@
 var when = require("when");
 var request = require('request');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var redis = require('redis'),
     redisClient = redis.createClient({
         url: process.env.REDIS_URL


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.